### PR TITLE
specify a shell in su

### DIFF
--- a/service/elasticsearch
+++ b/service/elasticsearch
@@ -465,7 +465,7 @@ checkUser() {
         then
             /sbin/runuser - $RUN_AS_USER -c "\"$REALPATH\" $2"
         else
-            su - $RUN_AS_USER -c "\"$REALPATH\" $2"
+            su - $RUN_AS_USER -s "/bin/sh" -c "\"$REALPATH\" $2"
         fi
 
         # Now that we are the original user again, we may need to clean up the lock file.


### PR DESCRIPTION
my elasticsearch user was created as a daemon user, which by default didn't have a shell

this was causing elasticsearch to bail silently

specifying the shell in the su line fixed the problem
