### PR TITLE
Proper service installation on Gentoo

### DIFF
--- a/service/elasticsearch
+++ b/service/elasticsearch
@@ -1033,6 +1033,16 @@ installdaemon() {
                     ln -s "$REALPATH" "/etc/init.d/$APP_NAME"
                     update-rc.d "$APP_NAME" defaults
                 fi
+	    elif [ -f /etc/gentoo-release ] ; then
+                eval echo  'Detected Gentoo:'
+                if [ -f "/etc/init.d/$APP_NAME" ] ; then
+                    eval echo  ' The $APP_LONG_NAME daemon is already installed.'
+                    exit 1
+                else
+                    eval echo  ' Installing the $APP_LONG_NAME daemon..'
+                    ln -s "$REALPATH" "/etc/init.d/$APP_NAME"
+                    rc-update add "$APP_NAME" default
+                fi
             else
                 eval echo  'Detected Linux:'
                 if [ -f "/etc/init.d/$APP_NAME" ] ; then
@@ -1207,6 +1217,16 @@ removedaemon() {
                 if [ -f "/etc/init.d/$APP_NAME" ] ; then
                     eval echo  ' Removing $APP_LONG_NAME daemon...'
                     update-rc.d -f "$APP_NAME" remove
+                    rm -f "/etc/init.d/$APP_NAME"
+                else
+                    eval echo  ' The $APP_LONG_NAME daemon is not currently installed.'
+                    exit 1
+                fi
+            elif [ -f /etc/gentoo-release ] ; then
+                eval echo  'Detected Gentoo:'
+                if [ -f "/etc/init.d/$APP_NAME" ] ; then
+                    eval echo  ' Removing $APP_LONG_NAME daemon...'
+                    rc-update del "$APP_NAME" default
                     rm -f "/etc/init.d/$APP_NAME"
                 else
                     eval echo  ' The $APP_LONG_NAME daemon is not currently installed.'


### PR DESCRIPTION
This uses the proper command-line script for managing runlevels instead of failing by using the standard Linux approach. (Gentoo does not have rcX.d-Folders)
