### PR TITLE
Set correct configuration default variable in .bat file

### DIFF
--- a/service/elasticsearch.bat
+++ b/service/elasticsearch.bat
@@ -15,7 +15,7 @@ set _WRAPPER_BASE=\exec\elasticsearch
 
 rem The name and location of the Wrapper configuration file.
 rem  (Do not remove quotes.)
-set _WRAPPER_CONF="..\elasticsearch.conf"
+set _WRAPPER_CONF_DEFAULT="..\elasticsearch.conf"
 
 rem _PASS_THROUGH tells the script to pass all arguments through to the JVM
 rem  as is.


### PR DESCRIPTION
The _WRAPPER_CONF_DEFAULT variable was being referenced but not set (_WRAPPER_CONF was used instead), resulting in the following error:

> FATAL  | wrapper  | Unable to resolve the full path of the configuration file, : The filename, directory name, or volume label syntax is incorrect. (0x7b)
