### PR TITLE
Resolve symbolic links in ES_HOME

### DIFF
--- a/service/elasticsearch
+++ b/service/elasticsearch
@@ -36,7 +36,7 @@ WRAPPER_CONF="$ES_HOME/bin/service/elasticsearch.conf"
 PRIORITY=
 
 # Location of the pid file.
-PIDDIR="."
+PIDDIR="$ES_HOME"
 
 # FIXED_COMMAND tells the script to use a hard coded action rather than
 # expecting the first parameter of the command line to be the command.

--- a/service/elasticsearch
+++ b/service/elasticsearch
@@ -20,7 +20,7 @@ done
 ES_HOME=`dirname "$SCRIPT"`/../..
 
 # make ELASTICSEARCH_HOME absolute
-export ES_HOME=`cd $ES_HOME; pwd`
+export ES_HOME=`cd $ES_HOME; pwd -P`
 
 
 # Application


### PR DESCRIPTION
I have installed Elasticsearch in a directory with symbolic links. Unfortunately, this breaks the service wrapper when matching the wrapper process name in the process list, and it accidentally removes the pid file even at start time.

To remedy this, I added the -P flag to the pwd command that is exporting ES_HOME. This resolves symbolic links in the current directory path.
