### PR TITLE
Read ES_HOME, APP_NAME and APP_LONG_NAME from JVM config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A service wrapper execution for elasticsearch using [Java Service Wrapper](http:
 Installation guide
 ==================
 
-Simply place the `service` directory under the elasticsearch `bin` directory and edit the `elasticsearch.conf` file to point to the correct elasticsearch home path.
+Simply edit the `elasticsearch.conf` file to point to the correct elasticsearch home path.
 
 ElasticSearch can be run as a service using the `elasticsearch` script located under `bin/service` location. The script accepts a single parameter with the following values:
 
@@ -47,4 +47,4 @@ This requires a commercial license for Java Service Wrapper. Licenses are bound 
 
 Once you have your license information, paste the extra `wrapper.license.*` lines into the `elasticsearch.conf` file. Then download the corresponding windows x86 64 bit build of the JSW.
 
-Copy `bin\wrapper.exe` to `bin\service\exec\elasticsearch-windows-x86-64.exe`, and `lib\wrapper.dll` and `lib\wrapper.jar` to `bin\service\lib` in your elasticsearch directory. Also make sure you have a 64-bit JRE installed. The service can then be installed and started as described above.
+Place the `service` directory under the elasticsearch `bin` directory. Copy `bin\wrapper.exe` to `bin\service\exec\elasticsearch-windows-x86-64.exe`, and `lib\wrapper.dll` and `lib\wrapper.jar` to `bin\service\lib` in your elasticsearch directory. Also make sure you have a 64-bit JRE installed. The service can then be installed and started as described above.

--- a/service/elasticsearch
+++ b/service/elasticsearch
@@ -16,16 +16,16 @@ while [ -h "$SCRIPT" ] ; do
   fi
 done
 
-# determine elasticsearch home
-ES_HOME=`dirname "$SCRIPT"`/../..
+# locate JVM config file
+ES_JAVA_CONF=`dirname "$SCRIPT"`/elasticsearch.conf
 
-# make ELASTICSEARCH_HOME absolute
-export ES_HOME=`cd $ES_HOME; pwd`
+# get ELASTICSEARCH_HOME from JVM level config file
+export ES_HOME=`cd $(grep '^set\.default\.ES_HOME=' $ES_JAVA_CONF | cut -d '=' -f 2); pwd`
 
 
-# Application
-APP_NAME="elasticsearch"
-APP_LONG_NAME="ElasticSearch"
+# Use the same application name in JVM config
+APP_NAME="$(grep '^wrapper\.name=' $ES_JAVA_CONF | cut -d '=' -f 2)"
+APP_LONG_NAME="$(grep '^wrapper\.displayname=' $ES_JAVA_CONF | cut -d '=' -f 2)"
 
 # Wrapper
 WRAPPER_CMD="$ES_HOME/bin/service/exec/elasticsearch"


### PR DESCRIPTION
This patch modifies the init.d service script to read existing values for elasticsearch home path and app name (service name) from elasticsearch.conf

Like this,  the wrapper is location independent on Linux. It is no longer required to be placed in bin of elasticsearch!
I can't tell the same about Windows (I don't know), that's why I moved that requirement in the Readme to the Windows section.

Thank you!
